### PR TITLE
:sparkles:  Feat: Header, Drawer 구현

### DIFF
--- a/components/base/Header/Header.tsx
+++ b/components/base/Header/Header.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import Image from 'next/image';
+import * as S from './Style';
+import { MenuBar } from 'components/base';
+
+import { IcoMenuBar, IcoClose, IcoArrow } from 'public/images';
+
+const Header = () => {
+  const [slideToggle, setSlideToggle] = useState(false);
+
+  const handleToggleMenu = (e: React.MouseEvent<HTMLOrSVGElement>) => {
+    const target = e.target as HTMLElement;
+    const targetElem = target.closest('.toggle-button');
+    if (targetElem) {
+      setSlideToggle(!slideToggle);
+    }
+  };
+  const handleCloseMenu = (e: React.MouseEvent<HTMLOrSVGElement>) => {
+    setSlideToggle(!slideToggle);
+  };
+
+  return (
+    <S.HeaderWrapper>
+      <S.HeaderInner>
+        <S.HamburgerContainer className={'toggle-button'}>
+          <Image src={IcoMenuBar} width="30" height="30" onClick={handleToggleMenu} />
+        </S.HamburgerContainer>
+        <S.Title>니콘내콘</S.Title>
+        <S.Hidden />
+      </S.HeaderInner>
+      <S.MyPageWrapper className={`toggle-button ${slideToggle ? 'show' : 'hidden'}`}>
+        <S.HeaderMenu>
+          <S.MenuWrapper>
+            <MenuBar img={IcoClose} onClick={handleCloseMenu}>
+              마이페이지
+            </MenuBar>
+            {/* <div>작성 공간</div> */}
+          </S.MenuWrapper>
+        </S.HeaderMenu>
+      </S.MyPageWrapper>
+    </S.HeaderWrapper>
+  );
+};
+
+export default Header;

--- a/components/base/Header/Style.ts
+++ b/components/base/Header/Style.ts
@@ -1,0 +1,76 @@
+import styled from 'styled-components';
+import { flexbox } from 'styles/commonStyle';
+import { font15 } from 'styles/font';
+
+export const HeaderWrapper = styled.div`
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 50px;
+  z-index: 3;
+  background: ${({ theme }) => theme.colors.white};
+`;
+
+export const HeaderInner = styled.div`
+  ${flexbox({ jc: 'between' })};
+  max-width: 1440px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 7px 19px;
+`;
+
+export const Title = styled.h1`
+  ${font15(600)}
+`;
+
+export const Hidden = styled.div`
+  width: 30px;
+  visibility: hidden;
+`;
+
+export const HamburgerContainer = styled.div``;
+
+export const MyPageWrapper = styled.div`
+  z-index: 6;
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.5);
+  &.hidden {
+    width: 0;
+    height: 100%;
+  }
+  &:not(.hidden) ul {
+    width: 100%;
+    transform: none;
+  }
+`;
+export const Image = styled.div``;
+
+export const HeaderMenu = styled.ul`
+  ${flexbox({})};
+  img {
+    display: none;
+  }
+  ${flexbox({ fd: 'column', jc: 'start', ai: 'start' })};
+  position: absolute;
+  transition: 0.45s;
+  transform: translateX(-280px);
+  width: 280px;
+  height: 100vh;
+  background: ${({ theme }) => theme.colors.white};
+`;
+
+export const MenuWrapper = styled.div`
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 50px;
+  z-index: 3;
+  background: ${({ theme }) => theme.colors.white};
+`;

--- a/components/base/Header/Style.ts
+++ b/components/base/Header/Style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { flexbox } from 'styles/commonStyle';
 import { font15 } from 'styles/font';
 
-export const HeaderWrapper = styled.div`
+export const HeaderWrapper = styled.header`
   position: fixed;
   left: 0;
   top: 0;
@@ -65,7 +65,7 @@ export const HeaderMenu = styled.ul`
   background: ${({ theme }) => theme.colors.white};
 `;
 
-export const MenuWrapper = styled.div`
+export const MenuWrapper = styled.header`
   position: fixed;
   left: 0;
   top: 0;

--- a/components/base/MenuBar/MenuBar.tsx
+++ b/components/base/MenuBar/MenuBar.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import * as S from './Style';
+import { MenuImage } from 'components/base';
+
+import { IcoMenuBar, IcoClose } from 'public/images';
+
+export interface MenuBarProps {
+  img: StaticImageData;
+  children: string;
+  onClick: (e: React.MouseEvent<HTMLOrSVGElement>) => void;
+}
+
+const MenuBar = ({ img, children, onClick }: MenuBarProps) => {
+  return (
+    <>
+      {img === IcoClose ? (
+        <S.HeaderInner>
+          <div></div>
+          <S.Title>{children}</S.Title>
+          <div>
+            <MenuImage img={img} num={'16'} onClick={onClick} />
+          </div>
+        </S.HeaderInner>
+      ) : (
+        <S.HeaderInner>
+          <div>
+            <MenuImage img={img} num={'18'} onClick={onClick} />
+          </div>
+          <S.Title>{children}</S.Title>
+          <div></div>
+        </S.HeaderInner>
+      )}
+    </>
+  );
+};
+
+export default MenuBar;

--- a/components/base/MenuBar/Style.ts
+++ b/components/base/MenuBar/Style.ts
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import { flexbox } from 'styles/commonStyle';
+import { font15 } from 'styles/font';
+
+export const HeaderInner = styled.div`
+  ${flexbox({ jc: 'between' })};
+  max-width: 1440px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 7px 19px;
+`;
+
+export const Title = styled.h1`
+  ${font15(600)}
+`;

--- a/components/base/MenuImage/MenuImage.tsx
+++ b/components/base/MenuImage/MenuImage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Image from 'next/image';
+
+export interface MenuBarProps {
+  img: StaticImageData;
+  num: string;
+  onClick: (e: React.MouseEvent<HTMLOrSVGElement>) => void;
+}
+
+const MenuImage = ({ img, num, onClick }: MenuBarProps) => {
+  return (
+    <div>
+      <Image src={img} width={num} height={num} onClick={onClick} />
+    </div>
+  );
+};
+
+export default MenuImage;

--- a/components/base/index.ts
+++ b/components/base/index.ts
@@ -1,2 +1,5 @@
 export { default as BuyButton } from './BuyButton/BuyButton';
 export { default as QuitButton } from './QuitButton/QuitButton';
+export { default as Header } from './Header/Header';
+export { default as MenuBar } from './MenuBar/MenuBar';
+export { default as MenuImage } from './MenuImage/MenuImage';


### PR DESCRIPTION
Closes #6
## Header 결과
![image](https://user-images.githubusercontent.com/48192081/153908276-d1876f8f-22fa-4460-8110-c32e4d3933f1.png)

## MenuBar 결과
![image](https://user-images.githubusercontent.com/48192081/153908304-18fdc136-d59b-4cad-9746-7cbc23c36a5e.png)

## MenuBar 사용법
![image](https://user-images.githubusercontent.com/48192081/153908567-c09d721b-d589-417a-a1e4-308e64840854.png)
* img에 저장한 이미지 IcoClose | IcoArrow
* onClick에 함수
## 마이페이지 내용 붙이는 곳
![image](https://user-images.githubusercontent.com/48192081/153908104-bd954cca-7a7e-4029-8018-3fa7f306cb9e.png)
